### PR TITLE
Add support for non-standard for loops

### DIFF
--- a/src/createContext.ts
+++ b/src/createContext.ts
@@ -329,7 +329,7 @@ export const importBuiltins = (context: Context, externalBuiltIns: CustomBuiltIn
       defineBuiltin(context, '__clearKernelCache()', gpu_lib.__clearKernelCache)
       defineBuiltin(
         context,
-        '__createKernelSource(ctr, end, initials, steps, operators, idx, externSource, localNames, arr, f, kernelId, functionEntries)',
+        '__createKernelSource(ctr, end, initials, steps, operators, isIncrements, idx, externSource, localNames, arr, f, kernelId, functionEntries)',
         gpu_lib.__createKernelSource
       )
     }

--- a/src/createContext.ts
+++ b/src/createContext.ts
@@ -329,7 +329,7 @@ export const importBuiltins = (context: Context, externalBuiltIns: CustomBuiltIn
       defineBuiltin(context, '__clearKernelCache()', gpu_lib.__clearKernelCache)
       defineBuiltin(
         context,
-        '__createKernelSource(shape, extern, localNames, output, fun, kernelId, customFunctions)',
+        '__createKernelSource(ctr, end, initials, steps, idx, externSource, localNames, arr, f, kernelId, functionEntries)',
         gpu_lib.__createKernelSource
       )
     }

--- a/src/createContext.ts
+++ b/src/createContext.ts
@@ -329,7 +329,7 @@ export const importBuiltins = (context: Context, externalBuiltIns: CustomBuiltIn
       defineBuiltin(context, '__clearKernelCache()', gpu_lib.__clearKernelCache)
       defineBuiltin(
         context,
-        '__createKernelSource(ctr, end, initials, steps, idx, externSource, localNames, arr, f, kernelId, functionEntries)',
+        '__createKernelSource(ctr, end, initials, steps, operators, idx, externSource, localNames, arr, f, kernelId, functionEntries)',
         gpu_lib.__createKernelSource
       )
     }

--- a/src/gpu/__tests__/evaluateComplexOk.ts
+++ b/src/gpu/__tests__/evaluateComplexOk.ts
@@ -3985,3 +3985,180 @@ test('external 4 for-loop evaluation correct', done => {
     }
   })
 })
+
+test('for-loop with different initial value correct', done => {
+  const code = stripIndent`
+    const N = 15;
+    const M = 15;
+    const arr = [];
+    for (let i = 0; i < N; i = i + 1) {
+        arr[i] = [];
+    }
+    for (let i = 5; i < N; i = i + 1) {
+        for (let j = 0; j < M; j = j + 1) {
+            arr[i][j] = 2 * i + j;
+        }
+    }
+    arr;
+    `
+  const expected = [
+    [],
+    [],
+    [],
+    [],
+    [],
+    [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24],
+    [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26],
+    [14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28],
+    [16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30],
+    [18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32],
+    [20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34],
+    [22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36],
+    [24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38],
+    [26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40],
+    [28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42]
+  ]
+
+  const context = mockContext(4, 'gpu')
+  const res = runInContext(code, context)
+  res.then(res => {
+    try {
+      expect(res['value']).toEqual(expected)
+      done()
+    } catch (error) {
+      done(error)
+    }
+  })
+})
+
+test('for-loop with different step size correct', done => {
+  const code = stripIndent`
+    const N = 15;
+    const M = 15;
+    const arr = [];
+    for (let i = 0; i < N; i = i + 1) {
+        arr[i] = [];
+    }
+    for (let i = 0; i < N; i = i + 2) {
+        for (let j = 0; j < M; j = j + 1) {
+            arr[i][j] = 2 * i + j;
+        }
+    }
+    arr;
+    `
+  const expected = [
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
+    [],
+    [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18],
+    [],
+    [8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22],
+    [],
+    [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26],
+    [],
+    [16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30],
+    [],
+    [20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34],
+    [],
+    [24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38],
+    [],
+    [28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42]
+  ]
+  const context = mockContext(4, 'gpu')
+  const res = runInContext(code, context)
+  res.then(res => {
+    try {
+      expect(res['value']).toEqual(expected)
+      done()
+    } catch (error) {
+      done(error)
+    }
+  })
+})
+
+test('for-loop with different initial value and step size correct', done => {
+  const code = stripIndent`
+    const N = 15;
+    const M = 15;
+    const arr = [];
+    for (let i = 0; i < N; i = i + 1) {
+        arr[i] = [];
+    }
+    for (let i = 5; i < N; i = i + 2) {
+        for (let j = 0; j < M; j = j + 1) {
+            arr[i][j] = 2 * i + j;
+        }
+    }
+    arr;
+    `
+  const expected = [
+    [],
+    [],
+    [],
+    [],
+    [],
+    [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24],
+    [],
+    [14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28],
+    [],
+    [18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32],
+    [],
+    [22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36],
+    [],
+    [26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40],
+    []
+  ]
+  const context = mockContext(4, 'gpu')
+  const res = runInContext(code, context)
+  res.then(res => {
+    try {
+      expect(res['value']).toEqual(expected)
+      done()
+    } catch (error) {
+      done(error)
+    }
+  })
+})
+
+test('nested for-loop with different initial values and step sizes correct', done => {
+  const code = stripIndent`
+    const N = 15;
+    const M = 15;
+    const arr = [];
+    for (let i = 0; i < N; i = i + 1) {
+        arr[i] = [];
+    }
+    for (let i = 1; i < N; i = i + 2) {
+        for (let j = 2; j < M; j = j + 3) {
+            arr[i][j] = 2 * i + j;
+        }
+    }
+    arr;
+    `
+  const expected = [
+    [],
+    [, , 4, , , 7, , , 10, , , 13, , , 16],
+    [],
+    [, , 8, , , 11, , , 14, , , 17, , , 20],
+    [],
+    [, , 12, , , 15, , , 18, , , 21, , , 24],
+    [],
+    [, , 16, , , 19, , , 22, , , 25, , , 28],
+    [],
+    [, , 20, , , 23, , , 26, , , 29, , , 32],
+    [],
+    [, , 24, , , 27, , , 30, , , 33, , , 36],
+    [],
+    [, , 28, , , 31, , , 34, , , 37, , , 40],
+    []
+  ]
+  const context = mockContext(4, 'gpu')
+  const res = runInContext(code, context)
+  res.then(res => {
+    try {
+      expect(res['value']).toEqual(expected)
+      done()
+    } catch (error) {
+      done(error)
+    }
+  })
+})

--- a/src/gpu/__tests__/evaluateComplexOk.ts
+++ b/src/gpu/__tests__/evaluateComplexOk.ts
@@ -4344,3 +4344,187 @@ test('for-loop with <= as operator and non-standard initial/step correct', done 
     }
   })
 })
+
+test('for-loop with decrement in the assignment', done => {
+  const code = stripIndent`
+    const N = 15;
+    const M = 15;
+    const arr = [];
+    for (let i = 0; i <= N; i = i + 1) {
+        arr[i] = [];
+    }
+    const step = 2;
+    for (let i = N; i > 1; i = i - step) {
+        for (let j = 0; j < M; j = j + 1) {
+            arr[i][j] = 2 * i + j;
+        }
+    }
+    arr;
+    `
+  const expected = [
+    [],
+    [],
+    [],
+    [6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20],
+    [],
+    [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24],
+    [],
+    [14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28],
+    [],
+    [18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32],
+    [],
+    [22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36],
+    [],
+    [26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40],
+    [],
+    [30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44]
+  ]
+  const context = mockContext(4, 'gpu')
+  const res = runInContext(code, context)
+  res.then(res => {
+    try {
+      expect(res['value']).toEqual(expected)
+      done()
+    } catch (error) {
+      done(error)
+    }
+  })
+})
+
+test('for-loop with >= operator, decrement in the assignment', done => {
+  const code = stripIndent`
+    const N = 15;
+    const M = 15;
+    const arr = [];
+    for (let i = 0; i <= N; i = i + 1) {
+        arr[i] = [];
+    }
+    const step = 2;
+    for (let i = N; i >= 1; i = i - step) {
+        for (let j = 0; j < M; j = j + 1) {
+            arr[i][j] = 2 * i + j;
+        }
+    }
+    arr;
+    `
+  const expected = [
+    [],
+    [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+    [],
+    [6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20],
+    [],
+    [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24],
+    [],
+    [14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28],
+    [],
+    [18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32],
+    [],
+    [22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36],
+    [],
+    [26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40],
+    [],
+    [30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44]
+  ]
+  const context = mockContext(4, 'gpu')
+  const res = runInContext(code, context)
+  res.then(res => {
+    try {
+      expect(res['value']).toEqual(expected)
+      done()
+    } catch (error) {
+      done(error)
+    }
+  })
+})
+
+test('for-loop incrementing by negative number', done => {
+  const code = stripIndent`
+    const N = 15;
+    const M = 15;
+    const arr = [];
+    for (let i = 0; i <= N; i = i + 1) {
+        arr[i] = [];
+    }
+    const step = -2;
+    for (let i = N; i >= 1; i = i + step) {
+        for (let j = 0; j < M; j = j + 1) {
+            arr[i][j] = 2 * i + j;
+        }
+    }
+    arr;
+    `
+  const expected = [
+    [],
+    [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+    [],
+    [6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20],
+    [],
+    [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24],
+    [],
+    [14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28],
+    [],
+    [18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32],
+    [],
+    [22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36],
+    [],
+    [26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40],
+    [],
+    [30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44]
+  ]
+  const context = mockContext(4, 'gpu')
+  const res = runInContext(code, context)
+  res.then(res => {
+    try {
+      expect(res['value']).toEqual(expected)
+      done()
+    } catch (error) {
+      done(error)
+    }
+  })
+})
+
+test('for-loop decrementing by negative number', done => {
+  const code = stripIndent`
+    const N = 15;
+    const M = 15;
+    const arr = [];
+    for (let i = 0; i <= N; i = i + 1) {
+        arr[i] = [];
+    }
+    const step = -2;
+    for (let i = 1; i <= N; i = i - step) {
+        for (let j = 0; j < M; j = j + 1) {
+            arr[i][j] = 2 * i + j;
+        }
+    }
+    arr;
+    `
+  const expected = [
+    [],
+    [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+    [],
+    [6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20],
+    [],
+    [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24],
+    [],
+    [14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28],
+    [],
+    [18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32],
+    [],
+    [22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36],
+    [],
+    [26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40],
+    [],
+    [30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44]
+  ]
+  const context = mockContext(4, 'gpu')
+  const res = runInContext(code, context)
+  res.then(res => {
+    try {
+      expect(res['value']).toEqual(expected)
+      done()
+    } catch (error) {
+      done(error)
+    }
+  })
+})

--- a/src/gpu/__tests__/evaluateComplexOk.ts
+++ b/src/gpu/__tests__/evaluateComplexOk.ts
@@ -4252,3 +4252,95 @@ test('for-loop with variable as step correct', done => {
     }
   })
 })
+
+test('for-loop with <= as operator correct', done => {
+  const code = stripIndent`
+    const N = 15;
+    const M = 15;
+    const arr = [];
+    for (let i = 0; i <= N; i = i + 1) {
+        arr[i] = [];
+    }
+    for (let i = 0; i <= N; i = i + 1) {
+        for (let j = 0; j < M; j = j + 1) {
+            arr[i][j] = 2 * i + j;
+        }
+    }
+    arr;
+    `
+  const expected = [
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
+    [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+    [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18],
+    [6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20],
+    [8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22],
+    [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24],
+    [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26],
+    [14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28],
+    [16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30],
+    [18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32],
+    [20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34],
+    [22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36],
+    [24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38],
+    [26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40],
+    [28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42],
+    [30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44]
+  ]
+  const context = mockContext(4, 'gpu')
+  const res = runInContext(code, context)
+  res.then(res => {
+    try {
+      expect(res['value']).toEqual(expected)
+      done()
+    } catch (error) {
+      done(error)
+    }
+  })
+})
+
+test('for-loop with <= as operator and non-standard initial/step correct', done => {
+  const code = stripIndent`
+    const N = 15;
+    const M = 15;
+    const arr = [];
+    for (let i = 0; i <= N; i = i + 1) {
+        arr[i] = [];
+    }
+    const initial = 5;
+    const step = 2;
+    for (let i = initial; i <= N; i = i + step) {
+        for (let j = 0; j < M; j = j + 1) {
+            arr[i][j] = 2 * i + j;
+        }
+    }
+    arr;
+    `
+  const expected = [
+    [],
+    [],
+    [],
+    [],
+    [],
+    [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24],
+    [],
+    [14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28],
+    [],
+    [18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32],
+    [],
+    [22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36],
+    [],
+    [26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40],
+    [],
+    [30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44]
+  ]
+  const context = mockContext(4, 'gpu')
+  const res = runInContext(code, context)
+  res.then(res => {
+    try {
+      expect(res['value']).toEqual(expected)
+      done()
+    } catch (error) {
+      done(error)
+    }
+  })
+})

--- a/src/gpu/__tests__/evaluateComplexOk.ts
+++ b/src/gpu/__tests__/evaluateComplexOk.ts
@@ -4119,7 +4119,7 @@ test('for-loop with different initial value and step size correct', done => {
   })
 })
 
-test('nested for-loop with different initial values and step sizes correct', done => {
+test('for-loop with different initial values and step sizes correct', done => {
   const code = stripIndent`
     const N = 15;
     const M = 15;
@@ -4150,6 +4150,96 @@ test('nested for-loop with different initial values and step sizes correct', don
     [],
     [, , 28, , , 31, , , 34, , , 37, , , 40],
     []
+  ]
+  const context = mockContext(4, 'gpu')
+  const res = runInContext(code, context)
+  res.then(res => {
+    try {
+      expect(res['value']).toEqual(expected)
+      done()
+    } catch (error) {
+      done(error)
+    }
+  })
+})
+
+test('for-loop with variable as initial correct', done => {
+  const code = stripIndent`
+    const N = 15;
+    const M = 15;
+    const arr = [];
+    for (let i = 0; i < N; i = i + 1) {
+        arr[i] = [];
+    }
+    const initial = 2;
+    for (let i = initial; i < N; i = i + 1) {
+        for (let j = 0; j < M; j = j + 1) {
+            arr[i][j] = 2 * i + j;
+        }
+    }
+    arr;
+    `
+  const expected = [
+    [],
+    [],
+    [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18],
+    [6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20],
+    [8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22],
+    [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24],
+    [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26],
+    [14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28],
+    [16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30],
+    [18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32],
+    [20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34],
+    [22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36],
+    [24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38],
+    [26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40],
+    [28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42]
+  ]
+  const context = mockContext(4, 'gpu')
+  const res = runInContext(code, context)
+  res.then(res => {
+    try {
+      expect(res['value']).toEqual(expected)
+      done()
+    } catch (error) {
+      done(error)
+    }
+  })
+})
+
+test('for-loop with variable as step correct', done => {
+  const code = stripIndent`
+    const N = 15;
+    const M = 15;
+    const arr = [];
+    for (let i = 0; i < N; i = i + 1) {
+        arr[i] = [];
+    }
+    const step = 2;
+    for (let i = 0; i < N; i = i + step) {
+        for (let j = 0; j < M; j = j + 1) {
+            arr[i][j] = 2 * i + j;
+        }
+    }
+    arr;
+    `
+  const expected = [
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
+    [],
+    [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18],
+    [],
+    [8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22],
+    [],
+    [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26],
+    [],
+    [16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30],
+    [],
+    [20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34],
+    [],
+    [24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38],
+    [],
+    [28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42]
   ]
   const context = mockContext(4, 'gpu')
   const res = runInContext(code, context)

--- a/src/gpu/__tests__/noTranspile.ts
+++ b/src/gpu/__tests__/noTranspile.ts
@@ -17,22 +17,6 @@ test('empty for loop does not get transpiled', () => {
   expect(cnt).toEqual(null)
 })
 
-test('simple for loop with different update does not get transpiled', () => {
-  const code = stripIndent`
-    let res = [];
-    for (let i = 0; i < 5; i = i + 2) {
-        res[i] = i;
-    }
-    `
-  const context = mockContext(4, 'gpu')
-  const program = parse(code, context)!
-  transpileToGPU(program)
-  const transpiled = generate(program)
-
-  const cnt = transpiled.match(/__createKernelSource/g)
-  expect(cnt).toEqual(null)
-})
-
 test('simple for loop with different loop variables does not get transpiled', () => {
   const code = stripIndent`
     let res = [];
@@ -55,22 +39,6 @@ test('simple for loop with const initialization does not get transpiled', () => 
     let res = [];
     let j = 0;
     for (const i = 0; i < 5; i = i + 1) {
-        res[i] = i;
-    }
-    `
-  const context = mockContext(4, 'gpu')
-  const program = parse(code, context)!
-  transpileToGPU(program)
-  const transpiled = generate(program)
-
-  const cnt = transpiled.match(/__createKernelSource/g)
-  expect(cnt).toEqual(null)
-})
-
-test('simple for loop with non-zero initialization does not get transpiled', () => {
-  const code = stripIndent`
-    let res = [];
-    for (let i = 1; i < 5; i = i + 1) {
         res[i] = i;
     }
     `

--- a/src/gpu/__tests__/runtimeError.ts
+++ b/src/gpu/__tests__/runtimeError.ts
@@ -6,6 +6,7 @@ test('__createKernel with uninitialized array throws error', () => {
   const ctr = ['i', 'j']
   const initials = [0, 0]
   const steps = [1, 1]
+  const operators = ['<', '<']
   const bounds = [5, 4]
   const idx = ['i', 'j']
   const extern = {}
@@ -18,7 +19,8 @@ test('__createKernel with uninitialized array throws error', () => {
   const f2 = function (i: any, j: any) {
     return i * j
   }
-  const f = () => __createKernel(ctr, bounds, initials, steps, idx, extern, f1, arr, f2, [])
+  const f = () =>
+    __createKernel(ctr, bounds, initials, steps, operators, idx, extern, f1, arr, f2, [])
   expect(f).toThrow(TypeError)
 })
 
@@ -26,6 +28,7 @@ test('__createKernel with 2 loops + uninitialized array throws error', () => {
   const ctr = ['i', 'j', 'k']
   const initials = [0, 0, 0]
   const steps = [1, 1, 1]
+  const operators = ['<', '<', '<']
   const bounds = [5, 4, 3]
   const extern = {}
   const idx = ['i', 'j', 'k']
@@ -41,6 +44,7 @@ test('__createKernel with 2 loops + uninitialized array throws error', () => {
   const f2 = function (i: any, j: any, k: any) {
     return i * j * k
   }
-  const f = () => __createKernel(ctr, bounds, initials, steps, idx, extern, f1, arr, f2, [])
+  const f = () =>
+    __createKernel(ctr, bounds, initials, steps, operators, idx, extern, f1, arr, f2, [])
   expect(f).toThrow(TypeError)
 })

--- a/src/gpu/__tests__/runtimeError.ts
+++ b/src/gpu/__tests__/runtimeError.ts
@@ -4,6 +4,8 @@ import { TypeError } from '../../utils/rttc'
 
 test('__createKernel with uninitialized array throws error', () => {
   const ctr = ['i', 'j']
+  const initials = [0, 0]
+  const steps = [1, 1]
   const bounds = [5, 4]
   const idx = ['i', 'j']
   const extern = {}
@@ -16,12 +18,14 @@ test('__createKernel with uninitialized array throws error', () => {
   const f2 = function (i: any, j: any) {
     return i * j
   }
-  const f = () => __createKernel(ctr, bounds, idx, extern, f1, arr, f2, [])
+  const f = () => __createKernel(ctr, bounds, initials, steps, idx, extern, f1, arr, f2, [])
   expect(f).toThrow(TypeError)
 })
 
 test('__createKernel with 2 loops + uninitialized array throws error', () => {
   const ctr = ['i', 'j', 'k']
+  const initials = [0, 0, 0]
+  const steps = [1, 1, 1]
   const bounds = [5, 4, 3]
   const extern = {}
   const idx = ['i', 'j', 'k']
@@ -37,6 +41,6 @@ test('__createKernel with 2 loops + uninitialized array throws error', () => {
   const f2 = function (i: any, j: any, k: any) {
     return i * j * k
   }
-  const f = () => __createKernel(ctr, bounds, idx, extern, f1, arr, f2, [])
+  const f = () => __createKernel(ctr, bounds, initials, steps, idx, extern, f1, arr, f2, [])
   expect(f).toThrow(TypeError)
 })

--- a/src/gpu/__tests__/runtimeOk.ts
+++ b/src/gpu/__tests__/runtimeOk.ts
@@ -3,6 +3,8 @@ import { __clearKernelCache, __createKernelSource } from '../lib'
 
 test('__createKernelSource with 1 loop returns correct result', () => {
   const ctr = ['i']
+  const initials = [0]
+  const steps = [1]
   const end = [5]
   const idx = ['i']
   const extern: [string, any][] = []
@@ -12,12 +14,14 @@ test('__createKernelSource with 1 loop returns correct result', () => {
   }
   const arr: number[] = []
   __clearKernelCache()
-  __createKernelSource(ctr, end, idx, extern, local, arr, f, 0, [])
+  __createKernelSource(ctr, end, initials, steps, idx, extern, local, arr, f, 0, [])
   expect(arr).toEqual([1, 1, 1, 1, 1])
 })
 
 test('__createKernelSource with 2 loops returns correct result', () => {
   const ctr = ['i', 'j']
+  const initials = [0, 0]
+  const steps = [1, 1]
   const end = [5, 4]
   const idx = ['i', 'j']
   const extern: [string, any][] = []
@@ -31,7 +35,7 @@ test('__createKernelSource with 2 loops returns correct result', () => {
     return i * j
   }
   __clearKernelCache()
-  __createKernelSource(ctr, end, idx, extern, local, arr, f, 0, [])
+  __createKernelSource(ctr, end, initials, steps, idx, extern, local, arr, f, 0, [])
   expect(arr).toEqual([
     [0, 0, 0, 0],
     [0, 1, 2, 3],
@@ -43,6 +47,8 @@ test('__createKernelSource with 2 loops returns correct result', () => {
 
 test('__createKernelSource with 3 loop returns correct result', () => {
   const ctr = ['i', 'j', 'k']
+  const initials = [0, 0, 0]
+  const steps = [1, 1, 1]
   const end = [5, 4, 3]
   const idx = ['i', 'j', 'k']
   const extern: [string, any][] = []
@@ -60,7 +66,7 @@ test('__createKernelSource with 3 loop returns correct result', () => {
     return i * j * k
   }
   __clearKernelCache()
-  __createKernelSource(ctr, end, idx, extern, local, arr, f, 0, [])
+  __createKernelSource(ctr, end, initials, steps, idx, extern, local, arr, f, 0, [])
   expect(arr).toEqual([
     [
       [0, 0, 0],
@@ -97,6 +103,8 @@ test('__createKernelSource with 3 loop returns correct result', () => {
 
 test('__createKernelSource with indices as counter combination returns correct result', () => {
   const ctr = ['i', 'j', 'k']
+  const initials = [0, 0, 0]
+  const steps = [1, 1, 1]
   const end = [5, 4, 3]
   const idx = ['k', 'i']
   const extern: [string, any][] = []
@@ -117,7 +125,7 @@ test('__createKernelSource with indices as counter combination returns correct r
     return i + k
   }
   __clearKernelCache()
-  __createKernelSource(ctr, end, idx, extern, local, arr, f, 0, [])
+  __createKernelSource(ctr, end, initials, steps, idx, extern, local, arr, f, 0, [])
   expect(arr).toEqual([
     [0, 1, 2, 3, 4],
     [1, 2, 3, 4, 5],
@@ -139,6 +147,8 @@ test('__createKernelSource with indices as counter combination returns correct r
 
 test('__createKernelSource with number constant as index returns correct result', () => {
   const ctr = ['i', 'j', 'k']
+  const initials = [0, 0, 0]
+  const steps = [1, 1, 1]
   const end = [5, 4, 3]
   const idx = ['k', 1, 'i']
   const extern: [string, any][] = []
@@ -159,7 +169,7 @@ test('__createKernelSource with number constant as index returns correct result'
     return i + k
   }
   __clearKernelCache()
-  __createKernelSource(ctr, end, idx, extern, local, arr, f, 0, [])
+  __createKernelSource(ctr, end, initials, steps, idx, extern, local, arr, f, 0, [])
   expect(arr).toEqual([
     [
       [1, 1, 1, 1, 1],
@@ -184,6 +194,8 @@ test('__createKernelSource with number constant as index returns correct result'
 
 test('__createKernelSource with counter not used in indices returns correct result', () => {
   const ctr = ['i', 'j', 'k', 'l']
+  const initials = [0, 0, 0, 0]
+  const steps = [1, 1, 1, 1]
   const end = [5, 4, 3, 2]
   const idx = ['i', 'j', 'k']
   const extern: [string, any][] = []
@@ -207,7 +219,7 @@ test('__createKernelSource with counter not used in indices returns correct resu
     return i * j * k * l
   }
   __clearKernelCache()
-  __createKernelSource(ctr, end, idx, extern, local, arr, f, 0, [])
+  __createKernelSource(ctr, end, initials, steps, idx, extern, local, arr, f, 0, [])
   expect(arr).toEqual([
     [
       [0, 0, 0],
@@ -244,6 +256,8 @@ test('__createKernelSource with counter not used in indices returns correct resu
 
 test('__createKernelSource with external variable as index returns correct result', () => {
   const ctr = ['i', 'j', 'k']
+  const initials = [0, 0, 0]
+  const steps = [1, 1, 1]
   const end = [5, 4, 3]
   const idx = ['x', 'j', 'k']
   const extern: [string, any][] = [['x', 4]]
@@ -265,7 +279,7 @@ test('__createKernelSource with external variable as index returns correct resul
   }
 
   __clearKernelCache()
-  __createKernelSource(ctr, end, idx, extern, local, arr, f, 0, [])
+  __createKernelSource(ctr, end, initials, steps, idx, extern, local, arr, f, 0, [])
   expect(arr).toEqual([
     [
       [1, 1, 1],
@@ -302,6 +316,8 @@ test('__createKernelSource with external variable as index returns correct resul
 
 test('__createKernelSource with repeated counter in indices returns correct result', () => {
   const ctr = ['i', 'j', 'k']
+  const initials = [0, 0, 0]
+  const steps = [1, 1, 1]
   const end = [5, 4, 3]
   const idx = ['j', 'j']
   const extern: [string, any][] = []
@@ -323,7 +339,7 @@ test('__createKernelSource with repeated counter in indices returns correct resu
   }
 
   __clearKernelCache()
-  __createKernelSource(ctr, end, idx, extern, local, arr, f, 0, [])
+  __createKernelSource(ctr, end, initials, steps, idx, extern, local, arr, f, 0, [])
   expect(arr).toEqual([
     [6, [1, 1, 1], [1, 1, 1], [1, 1, 1]],
     [[1, 1, 1], 6, [1, 1, 1], [1, 1, 1]],

--- a/src/gpu/__tests__/runtimeOk.ts
+++ b/src/gpu/__tests__/runtimeOk.ts
@@ -7,6 +7,7 @@ test('__createKernelSource with 1 loop returns correct result', () => {
   const steps = [1]
   const end = [5]
   const operators = ['<']
+  const isIncrements = [true]
   const idx = ['i']
   const extern: [string, any][] = []
   const local: string[] = []
@@ -15,7 +16,21 @@ test('__createKernelSource with 1 loop returns correct result', () => {
   }
   const arr: number[] = []
   __clearKernelCache()
-  __createKernelSource(ctr, end, initials, steps, operators, idx, extern, local, arr, f, 0, [])
+  __createKernelSource(
+    ctr,
+    end,
+    initials,
+    steps,
+    operators,
+    isIncrements,
+    idx,
+    extern,
+    local,
+    arr,
+    f,
+    0,
+    []
+  )
   expect(arr).toEqual([1, 1, 1, 1, 1])
 })
 
@@ -25,6 +40,7 @@ test('__createKernelSource with 2 loops returns correct result', () => {
   const steps = [1, 1]
   const end = [5, 4]
   const operators = ['<', '<']
+  const isIncrements = [true, true]
   const idx = ['i', 'j']
   const extern: [string, any][] = []
   const local: string[] = []
@@ -37,7 +53,21 @@ test('__createKernelSource with 2 loops returns correct result', () => {
     return i * j
   }
   __clearKernelCache()
-  __createKernelSource(ctr, end, initials, steps, operators, idx, extern, local, arr, f, 0, [])
+  __createKernelSource(
+    ctr,
+    end,
+    initials,
+    steps,
+    operators,
+    isIncrements,
+    idx,
+    extern,
+    local,
+    arr,
+    f,
+    0,
+    []
+  )
   expect(arr).toEqual([
     [0, 0, 0, 0],
     [0, 1, 2, 3],
@@ -52,6 +82,7 @@ test('__createKernelSource with 3 loop returns correct result', () => {
   const initials = [0, 0, 0]
   const steps = [1, 1, 1]
   const operators = ['<', '<', '<']
+  const isIncrements = [true, true, true]
   const end = [5, 4, 3]
   const idx = ['i', 'j', 'k']
   const extern: [string, any][] = []
@@ -69,7 +100,21 @@ test('__createKernelSource with 3 loop returns correct result', () => {
     return i * j * k
   }
   __clearKernelCache()
-  __createKernelSource(ctr, end, initials, steps, operators, idx, extern, local, arr, f, 0, [])
+  __createKernelSource(
+    ctr,
+    end,
+    initials,
+    steps,
+    operators,
+    isIncrements,
+    idx,
+    extern,
+    local,
+    arr,
+    f,
+    0,
+    []
+  )
   expect(arr).toEqual([
     [
       [0, 0, 0],
@@ -109,6 +154,7 @@ test('__createKernelSource with indices as counter combination returns correct r
   const initials = [0, 0, 0]
   const steps = [1, 1, 1]
   const operators = ['<', '<', '<']
+  const isIncrements = [true, true, true]
   const end = [5, 4, 3]
   const idx = ['k', 'i']
   const extern: [string, any][] = []
@@ -129,7 +175,21 @@ test('__createKernelSource with indices as counter combination returns correct r
     return i + k
   }
   __clearKernelCache()
-  __createKernelSource(ctr, end, initials, steps, operators, idx, extern, local, arr, f, 0, [])
+  __createKernelSource(
+    ctr,
+    end,
+    initials,
+    steps,
+    operators,
+    isIncrements,
+    idx,
+    extern,
+    local,
+    arr,
+    f,
+    0,
+    []
+  )
   expect(arr).toEqual([
     [0, 1, 2, 3, 4],
     [1, 2, 3, 4, 5],
@@ -154,6 +214,7 @@ test('__createKernelSource with number constant as index returns correct result'
   const initials = [0, 0, 0]
   const steps = [1, 1, 1]
   const operators = ['<', '<', '<']
+  const isIncrements = [true, true, true]
   const end = [5, 4, 3]
   const idx = ['k', 1, 'i']
   const extern: [string, any][] = []
@@ -174,7 +235,21 @@ test('__createKernelSource with number constant as index returns correct result'
     return i + k
   }
   __clearKernelCache()
-  __createKernelSource(ctr, end, initials, steps, operators, idx, extern, local, arr, f, 0, [])
+  __createKernelSource(
+    ctr,
+    end,
+    initials,
+    steps,
+    operators,
+    isIncrements,
+    idx,
+    extern,
+    local,
+    arr,
+    f,
+    0,
+    []
+  )
   expect(arr).toEqual([
     [
       [1, 1, 1, 1, 1],
@@ -202,6 +277,7 @@ test('__createKernelSource with counter not used in indices returns correct resu
   const initials = [0, 0, 0, 0]
   const steps = [1, 1, 1, 1]
   const operators = ['<', '<', '<', '<']
+  const isIncrements = [true, true, true, true]
   const end = [5, 4, 3, 2]
   const idx = ['i', 'j', 'k']
   const extern: [string, any][] = []
@@ -225,7 +301,21 @@ test('__createKernelSource with counter not used in indices returns correct resu
     return i * j * k * l
   }
   __clearKernelCache()
-  __createKernelSource(ctr, end, initials, steps, operators, idx, extern, local, arr, f, 0, [])
+  __createKernelSource(
+    ctr,
+    end,
+    initials,
+    steps,
+    operators,
+    isIncrements,
+    idx,
+    extern,
+    local,
+    arr,
+    f,
+    0,
+    []
+  )
   expect(arr).toEqual([
     [
       [0, 0, 0],
@@ -265,6 +355,7 @@ test('__createKernelSource with external variable as index returns correct resul
   const initials = [0, 0, 0]
   const steps = [1, 1, 1]
   const operators = ['<', '<', '<']
+  const isIncrements = [true, true, true]
   const end = [5, 4, 3]
   const idx = ['x', 'j', 'k']
   const extern: [string, any][] = [['x', 4]]
@@ -286,7 +377,21 @@ test('__createKernelSource with external variable as index returns correct resul
   }
 
   __clearKernelCache()
-  __createKernelSource(ctr, end, initials, steps, operators, idx, extern, local, arr, f, 0, [])
+  __createKernelSource(
+    ctr,
+    end,
+    initials,
+    steps,
+    operators,
+    isIncrements,
+    idx,
+    extern,
+    local,
+    arr,
+    f,
+    0,
+    []
+  )
   expect(arr).toEqual([
     [
       [1, 1, 1],
@@ -326,6 +431,7 @@ test('__createKernelSource with repeated counter in indices returns correct resu
   const initials = [0, 0, 0]
   const steps = [1, 1, 1]
   const operators = ['<', '<', '<']
+  const isIncrements = [true, true, true]
   const end = [5, 4, 3]
   const idx = ['j', 'j']
   const extern: [string, any][] = []
@@ -347,7 +453,21 @@ test('__createKernelSource with repeated counter in indices returns correct resu
   }
 
   __clearKernelCache()
-  __createKernelSource(ctr, end, initials, steps, operators, idx, extern, local, arr, f, 0, [])
+  __createKernelSource(
+    ctr,
+    end,
+    initials,
+    steps,
+    operators,
+    isIncrements,
+    idx,
+    extern,
+    local,
+    arr,
+    f,
+    0,
+    []
+  )
   expect(arr).toEqual([
     [6, [1, 1, 1], [1, 1, 1], [1, 1, 1]],
     [[1, 1, 1], 6, [1, 1, 1], [1, 1, 1]],

--- a/src/gpu/__tests__/runtimeOk.ts
+++ b/src/gpu/__tests__/runtimeOk.ts
@@ -6,6 +6,7 @@ test('__createKernelSource with 1 loop returns correct result', () => {
   const initials = [0]
   const steps = [1]
   const end = [5]
+  const operators = ['<']
   const idx = ['i']
   const extern: [string, any][] = []
   const local: string[] = []
@@ -14,7 +15,7 @@ test('__createKernelSource with 1 loop returns correct result', () => {
   }
   const arr: number[] = []
   __clearKernelCache()
-  __createKernelSource(ctr, end, initials, steps, idx, extern, local, arr, f, 0, [])
+  __createKernelSource(ctr, end, initials, steps, operators, idx, extern, local, arr, f, 0, [])
   expect(arr).toEqual([1, 1, 1, 1, 1])
 })
 
@@ -23,6 +24,7 @@ test('__createKernelSource with 2 loops returns correct result', () => {
   const initials = [0, 0]
   const steps = [1, 1]
   const end = [5, 4]
+  const operators = ['<', '<']
   const idx = ['i', 'j']
   const extern: [string, any][] = []
   const local: string[] = []
@@ -35,7 +37,7 @@ test('__createKernelSource with 2 loops returns correct result', () => {
     return i * j
   }
   __clearKernelCache()
-  __createKernelSource(ctr, end, initials, steps, idx, extern, local, arr, f, 0, [])
+  __createKernelSource(ctr, end, initials, steps, operators, idx, extern, local, arr, f, 0, [])
   expect(arr).toEqual([
     [0, 0, 0, 0],
     [0, 1, 2, 3],
@@ -49,6 +51,7 @@ test('__createKernelSource with 3 loop returns correct result', () => {
   const ctr = ['i', 'j', 'k']
   const initials = [0, 0, 0]
   const steps = [1, 1, 1]
+  const operators = ['<', '<', '<']
   const end = [5, 4, 3]
   const idx = ['i', 'j', 'k']
   const extern: [string, any][] = []
@@ -66,7 +69,7 @@ test('__createKernelSource with 3 loop returns correct result', () => {
     return i * j * k
   }
   __clearKernelCache()
-  __createKernelSource(ctr, end, initials, steps, idx, extern, local, arr, f, 0, [])
+  __createKernelSource(ctr, end, initials, steps, operators, idx, extern, local, arr, f, 0, [])
   expect(arr).toEqual([
     [
       [0, 0, 0],
@@ -105,6 +108,7 @@ test('__createKernelSource with indices as counter combination returns correct r
   const ctr = ['i', 'j', 'k']
   const initials = [0, 0, 0]
   const steps = [1, 1, 1]
+  const operators = ['<', '<', '<']
   const end = [5, 4, 3]
   const idx = ['k', 'i']
   const extern: [string, any][] = []
@@ -125,7 +129,7 @@ test('__createKernelSource with indices as counter combination returns correct r
     return i + k
   }
   __clearKernelCache()
-  __createKernelSource(ctr, end, initials, steps, idx, extern, local, arr, f, 0, [])
+  __createKernelSource(ctr, end, initials, steps, operators, idx, extern, local, arr, f, 0, [])
   expect(arr).toEqual([
     [0, 1, 2, 3, 4],
     [1, 2, 3, 4, 5],
@@ -149,6 +153,7 @@ test('__createKernelSource with number constant as index returns correct result'
   const ctr = ['i', 'j', 'k']
   const initials = [0, 0, 0]
   const steps = [1, 1, 1]
+  const operators = ['<', '<', '<']
   const end = [5, 4, 3]
   const idx = ['k', 1, 'i']
   const extern: [string, any][] = []
@@ -169,7 +174,7 @@ test('__createKernelSource with number constant as index returns correct result'
     return i + k
   }
   __clearKernelCache()
-  __createKernelSource(ctr, end, initials, steps, idx, extern, local, arr, f, 0, [])
+  __createKernelSource(ctr, end, initials, steps, operators, idx, extern, local, arr, f, 0, [])
   expect(arr).toEqual([
     [
       [1, 1, 1, 1, 1],
@@ -196,6 +201,7 @@ test('__createKernelSource with counter not used in indices returns correct resu
   const ctr = ['i', 'j', 'k', 'l']
   const initials = [0, 0, 0, 0]
   const steps = [1, 1, 1, 1]
+  const operators = ['<', '<', '<', '<']
   const end = [5, 4, 3, 2]
   const idx = ['i', 'j', 'k']
   const extern: [string, any][] = []
@@ -219,7 +225,7 @@ test('__createKernelSource with counter not used in indices returns correct resu
     return i * j * k * l
   }
   __clearKernelCache()
-  __createKernelSource(ctr, end, initials, steps, idx, extern, local, arr, f, 0, [])
+  __createKernelSource(ctr, end, initials, steps, operators, idx, extern, local, arr, f, 0, [])
   expect(arr).toEqual([
     [
       [0, 0, 0],
@@ -258,6 +264,7 @@ test('__createKernelSource with external variable as index returns correct resul
   const ctr = ['i', 'j', 'k']
   const initials = [0, 0, 0]
   const steps = [1, 1, 1]
+  const operators = ['<', '<', '<']
   const end = [5, 4, 3]
   const idx = ['x', 'j', 'k']
   const extern: [string, any][] = [['x', 4]]
@@ -279,7 +286,7 @@ test('__createKernelSource with external variable as index returns correct resul
   }
 
   __clearKernelCache()
-  __createKernelSource(ctr, end, initials, steps, idx, extern, local, arr, f, 0, [])
+  __createKernelSource(ctr, end, initials, steps, operators, idx, extern, local, arr, f, 0, [])
   expect(arr).toEqual([
     [
       [1, 1, 1],
@@ -318,6 +325,7 @@ test('__createKernelSource with repeated counter in indices returns correct resu
   const ctr = ['i', 'j', 'k']
   const initials = [0, 0, 0]
   const steps = [1, 1, 1]
+  const operators = ['<', '<', '<']
   const end = [5, 4, 3]
   const idx = ['j', 'j']
   const extern: [string, any][] = []
@@ -339,7 +347,7 @@ test('__createKernelSource with repeated counter in indices returns correct resu
   }
 
   __clearKernelCache()
-  __createKernelSource(ctr, end, initials, steps, idx, extern, local, arr, f, 0, [])
+  __createKernelSource(ctr, end, initials, steps, operators, idx, extern, local, arr, f, 0, [])
   expect(arr).toEqual([
     [6, [1, 1, 1], [1, 1, 1], [1, 1, 1]],
     [[1, 1, 1], 6, [1, 1, 1], [1, 1, 1]],

--- a/src/gpu/__tests__/runtimeTranspile.ts
+++ b/src/gpu/__tests__/runtimeTranspile.ts
@@ -15,9 +15,11 @@ test('gpuRuntimeTranspile replaces math function identifiers', () => {
   const localNames = new Set<string>()
   localNames.add('x')
   const end = [1, 2, 3]
+  const initials = [0, 0, 0]
+  const steps = [1, 1, 1]
   const idx = ['i', 'j', 'k']
 
-  const res = gpuRuntimeTranspile(arrowFn, localNames, end, idx, new Set())
+  const res = gpuRuntimeTranspile(arrowFn, localNames, end, initials, steps, idx, new Set())
   let found = false
   simple(res, {
     Identifier(node: es.Identifier) {
@@ -49,9 +51,11 @@ test('gpuRuntimeTranspile replaces external identifiers', () => {
   const localNames = new Set<string>()
   localNames.add('x')
   const end = [1, 2, 3]
+  const initials = [0, 0, 0]
+  const steps = [1, 1, 1]
   const idx = ['i', 'j', 'k']
 
-  const res = gpuRuntimeTranspile(arrowFn, localNames, end, idx, new Set())
+  const res = gpuRuntimeTranspile(arrowFn, localNames, end, initials, steps, idx, new Set())
   let found = false
   simple(res, {
     Identifier(node: es.Identifier) {
@@ -85,9 +89,11 @@ test('gpuRuntimeTranspile update reference to counters not used as index', () =>
   const localNames = new Set<string>()
   localNames.add('x')
   const end = [1, 2, 3]
+  const initials = [0, 0, 0]
+  const steps = [1, 1, 1]
   const idx = ['i']
 
-  const res = gpuRuntimeTranspile(arrowFn, localNames, end, idx, new Set())
+  const res = gpuRuntimeTranspile(arrowFn, localNames, end, initials, steps, idx, new Set())
   let found = false
   const checkId = (node: es.Node, id: string) => {
     // this.thread.id
@@ -145,9 +151,11 @@ test('gpuRuntimeTranspile update references to counters used as index', () => {
   const localNames = new Set<string>()
   localNames.add('x')
   const end = [1, 2, 3]
+  const initials = [0, 0, 0]
+  const steps = [1, 1, 1]
   const idx = ['i', 'j']
 
-  const res = gpuRuntimeTranspile(arrowFn, localNames, end, idx, new Set())
+  const res = gpuRuntimeTranspile(arrowFn, localNames, end, initials, steps, idx, new Set())
   let found = false
   const checkId = (node: es.Node, id: string) => {
     // this.thread.id
@@ -204,9 +212,11 @@ test('gpuRuntimeTranspile update references to counters used as index out of ord
   const localNames = new Set<string>()
   localNames.add('x')
   const end = [1, 2, 3]
+  const initials = [0, 0, 0]
+  const steps = [1, 1, 1]
   const idx = ['j', 1, 'k', 'i']
 
-  const res = gpuRuntimeTranspile(arrowFn, localNames, end, idx, new Set())
+  const res = gpuRuntimeTranspile(arrowFn, localNames, end, initials, steps, idx, new Set())
   let found = false
   const checkId = (node: es.Node, id: string) => {
     // this.thread.id
@@ -262,9 +272,11 @@ test('gpuRuntimeTranspile update references to counters used as index repeated',
   const localNames = new Set<string>()
   localNames.add('x')
   const end = [1, 2, 3]
+  const initials = [0, 0, 0]
+  const steps = [1, 1, 1]
   const idx = ['i', 'j', 'k']
 
-  const res = gpuRuntimeTranspile(arrowFn, localNames, end, idx, new Set())
+  const res = gpuRuntimeTranspile(arrowFn, localNames, end, initials, steps, idx, new Set())
   let found = false
   const checkId = (node: es.Node, id: string) => {
     // this.thread.id

--- a/src/gpu/__tests__/runtimeUtils.ts
+++ b/src/gpu/__tests__/runtimeUtils.ts
@@ -3,70 +3,90 @@ import { getGPUKernelDimensions, checkArray, buildArray } from '../lib'
 test('getGPUKernelDimensions with counter prefix returns correct dimensions', () => {
   const ctr = ['i', 'j', 'k']
   const end = [3, 5, 1]
+  const initials = [0, 0, 0]
+  const steps = [1, 1, 1]
   const idx = ['i', 'j', 'k']
-  const kernelDim = getGPUKernelDimensions(ctr, end, idx)
+  const kernelDim = getGPUKernelDimensions(ctr, end, initials, steps, idx)
   expect(kernelDim).toEqual([1, 5, 3])
 
   const ctr2 = ['i', 'j', 'k', 'l']
   const end2 = [3, 5, 1, 2]
+  const initials2 = [0, 0, 0, 0]
+  const steps2 = [1, 1, 1, 1]
   const idx2 = ['i', 'j']
-  const kernelDim2 = getGPUKernelDimensions(ctr2, end2, idx2)
+  const kernelDim2 = getGPUKernelDimensions(ctr2, end2, initials2, steps2, idx2)
   expect(kernelDim2).toEqual([5, 3])
 })
 
 test('getGPUKernlDimensions with counter combination returns correct dimensions', () => {
   const ctr = ['i', 'j', 'k']
   const end = [3, 2, 5]
+  const initials = [0, 0, 0]
+  const steps = [1, 1, 1]
   const idx = ['j', 'k', 'i']
-  const kernelDim = getGPUKernelDimensions(ctr, end, idx)
+  const kernelDim = getGPUKernelDimensions(ctr, end, initials, steps, idx)
   expect(kernelDim).toEqual([3, 5, 2])
 
   const ctr2 = ['i', 'j', 'k', 'l']
   const end2 = [3, 5, 1, 2]
+  const initials2 = [0, 0, 0, 0]
+  const steps2 = [1, 1, 1, 1]
   const idx2 = ['k', 'i']
-  const kernelDim2 = getGPUKernelDimensions(ctr2, end2, idx2)
+  const kernelDim2 = getGPUKernelDimensions(ctr2, end2, initials2, steps2, idx2)
   expect(kernelDim2).toEqual([3, 1])
 })
 
 test('getGPUKernlDimensions with numbers returns correct dimensions', () => {
   const ctr = ['i', 'j', 'k']
   const end = [3, 2, 5]
+  const initials = [0, 0, 0]
+  const steps = [1, 1, 1]
   const idx = ['j', '1', 'i']
-  const kernelDim = getGPUKernelDimensions(ctr, end, idx)
+  const kernelDim = getGPUKernelDimensions(ctr, end, initials, steps, idx)
   expect(kernelDim).toEqual([3, 2])
 
   const ctr2 = ['i', 'j', 'k', 'l']
   const end2 = [3, 5, 1, 2]
+  const initials2 = [0, 0, 0, 0]
+  const steps2 = [1, 1, 1, 1]
   const idx2 = [3, 'i']
-  const kernelDim2 = getGPUKernelDimensions(ctr2, end2, idx2)
+  const kernelDim2 = getGPUKernelDimensions(ctr2, end2, initials2, steps2, idx2)
   expect(kernelDim2).toEqual([3])
 })
 
 test('getGPUKernelDimensions with external variables returns correct dimensions', () => {
   const ctr = ['i', 'j', 'k']
   const end = [3, 2, 5]
+  const initials = [0, 0, 0]
+  const steps = [1, 1, 1]
   const idx = ['test', '1', 'i']
-  const kernelDim = getGPUKernelDimensions(ctr, end, idx)
+  const kernelDim = getGPUKernelDimensions(ctr, end, initials, steps, idx)
   expect(kernelDim).toEqual([3])
 
   const ctr2 = ['i', 'j', 'k', 'l']
   const end2 = [3, 5, 1, 2]
+  const initials2 = [0, 0, 0, 0]
+  const steps2 = [1, 1, 1, 1]
   const idx2 = ['l', 'test', 'k']
-  const kernelDim2 = getGPUKernelDimensions(ctr2, end2, idx2)
+  const kernelDim2 = getGPUKernelDimensions(ctr2, end2, initials2, steps2, idx2)
   expect(kernelDim2).toEqual([1, 2])
 })
 
 test('getGPUKernelDimensions with repeated counters returns correct dimensions', () => {
   const ctr = ['i', 'j', 'k']
   const end = [3, 2, 5]
+  const initials = [0, 0, 0]
+  const steps = [1, 1, 1]
   const idx = ['i', 'i', 'k']
-  const kernelDim = getGPUKernelDimensions(ctr, end, idx)
+  const kernelDim = getGPUKernelDimensions(ctr, end, initials, steps, idx)
   expect(kernelDim).toEqual([5, 3])
 
   const ctr2 = ['i', 'j', 'k', 'l']
   const end2 = [3, 5, 1, 2]
+  const initials2 = [0, 0, 0, 0]
+  const steps2 = [1, 1, 1, 1]
   const idx2 = ['l', 'k', 'l']
-  const kernelDim2 = getGPUKernelDimensions(ctr2, end2, idx2)
+  const kernelDim2 = getGPUKernelDimensions(ctr2, end2, initials2, steps2, idx2)
   expect(kernelDim2).toEqual([1, 2])
 })
 
@@ -266,6 +286,8 @@ test('checkArray returns false when array is invalid with repeated counters', ()
 test('buildArray with counter prefix performs correct assignment', () => {
   let ctr = ['i', 'j', 'k']
   let end = [3, 3, 2]
+  let initials = [0, 0, 0]
+  let steps = [1, 1, 1]
   let idx = ['i', 'j', 'k']
   let ext = {}
   let res: any = [
@@ -319,11 +341,13 @@ test('buildArray with counter prefix performs correct assignment', () => {
       [1, 1, 2]
     ]
   ]
-  buildArray(res, ctr, end, idx, ext, arr)
+  buildArray(res, ctr, end, initials, steps, idx, ext, arr)
   expect(arr).toEqual(exp)
 
   ctr = ['i', 'j', 'k', 'l']
   end = [1, 3, 2, 4]
+  initials = [0, 0, 0, 0]
+  steps = [1, 1, 1, 1]
   idx = ['i', 'j']
   ext = {}
   res = [[1, 1, 1]]
@@ -357,13 +381,15 @@ test('buildArray with counter prefix performs correct assignment', () => {
       [2, 2, 2]
     ]
   ]
-  buildArray(res, ctr, end, idx, ext, arr)
+  buildArray(res, ctr, end, initials, steps, idx, ext, arr)
   expect(arr).toEqual(exp)
 })
 
 test('buildArray with counter combination performs correct assignment', () => {
   let ctr = ['i', 'j', 'k']
   let end = [1, 3, 2]
+  let initials = [0, 0, 0]
+  let steps = [1, 1, 1]
   let idx = ['k', 'i', 'j']
   let ext = {}
   let res: any = [[[1, 1, 1]], [[1, 1, 1]]]
@@ -401,11 +427,13 @@ test('buildArray with counter combination performs correct assignment', () => {
       [2, 2, 2]
     ]
   ]
-  buildArray(res, ctr, end, idx, ext, arr)
+  buildArray(res, ctr, end, initials, steps, idx, ext, arr)
   expect(arr).toEqual(exp)
 
   ctr = ['i', 'j', 'k', 'l']
   end = [1, 3, 2, 4]
+  initials = [0, 0, 0, 0]
+  steps = [1, 1, 1, 1]
   idx = ['l', 'j']
   ext = {}
   res = [
@@ -442,13 +470,15 @@ test('buildArray with counter combination performs correct assignment', () => {
     [1, 1, 1],
     [1, 1, 1]
   ]
-  buildArray(res, ctr, end, idx, ext, arr)
+  buildArray(res, ctr, end, initials, steps, idx, ext, arr)
   expect(arr).toEqual(exp)
 })
 
 test('buildArray with numbers performs correct assignment', () => {
   let ctr = ['i', 'j', 'k']
   let end = [1, 2, 3]
+  let initials = [0, 0, 0]
+  let steps = [1, 1, 1]
   let idx = ['i', 1, 'j']
   let ext = {}
   let res: any = [[1, 1]]
@@ -486,11 +516,13 @@ test('buildArray with numbers performs correct assignment', () => {
       [2, 2, 2]
     ]
   ]
-  buildArray(res, ctr, end, idx, ext, arr)
+  buildArray(res, ctr, end, initials, steps, idx, ext, arr)
   expect(arr).toEqual(exp)
 
   ctr = ['i', 'j', 'k']
   end = [1, 2, 3]
+  initials = [0, 0, 0]
+  steps = [1, 1, 1]
   idx = [2, 1, 'k']
   ext = {}
   res = [1, 1, 1]
@@ -528,13 +560,15 @@ test('buildArray with numbers performs correct assignment', () => {
       [2, 2, 2]
     ]
   ]
-  buildArray(res, ctr, end, idx, ext, arr)
+  buildArray(res, ctr, end, initials, steps, idx, ext, arr)
   expect(arr).toEqual(exp)
 })
 
 test('buildArray with external variables performs correct assignment', () => {
   let ctr = ['i', 'j', 'k']
   let end = [1, 2, 3]
+  let initials = [0, 0, 0]
+  let steps = [1, 1, 1]
   let idx = ['i', 'x', 'j']
   let ext: any = { x: 1 }
   let res: any = [[1, 1]]
@@ -572,11 +606,13 @@ test('buildArray with external variables performs correct assignment', () => {
       [2, 2, 2]
     ]
   ]
-  buildArray(res, ctr, end, idx, ext, arr)
+  buildArray(res, ctr, end, initials, steps, idx, ext, arr)
   expect(arr).toEqual(exp)
 
   ctr = ['i', 'j', 'k']
   end = [1, 2, 3]
+  initials = [0, 0, 0]
+  steps = [1, 1, 1]
   idx = ['x', 'y', 'k']
   ext = { x: 2, y: 1 }
   res = [1, 1, 1]
@@ -614,13 +650,15 @@ test('buildArray with external variables performs correct assignment', () => {
       [2, 2, 2]
     ]
   ]
-  buildArray(res, ctr, end, idx, ext, arr)
+  buildArray(res, ctr, end, initials, steps, idx, ext, arr)
   expect(arr).toEqual(exp)
 })
 
 test('buildArray with repeated counters performs correct assignment', () => {
   const ctr = ['i', 'j', 'k']
   const end = [1, 2, 3]
+  const initials = [0, 0, 0]
+  const steps = [1, 1, 1]
   const idx = ['j', 'j', 'k']
   const ext: any = {}
   const res: any = [
@@ -661,6 +699,6 @@ test('buildArray with repeated counters performs correct assignment', () => {
       [2, 2, 2]
     ]
   ]
-  buildArray(res, ctr, end, idx, ext, arr)
+  buildArray(res, ctr, end, initials, steps, idx, ext, arr)
   expect(arr).toEqual(exp)
 })

--- a/src/gpu/__tests__/runtimeUtils.ts
+++ b/src/gpu/__tests__/runtimeUtils.ts
@@ -1,4 +1,4 @@
-import { getGPUKernelDimensions, checkArray, buildArray } from '../lib'
+import { getGPUKernelDimensions, checkArray, buildArray, checkValidLoops } from '../lib'
 
 test('getGPUKernelDimensions with counter prefix returns correct dimensions', () => {
   const ctr = ['i', 'j', 'k']
@@ -701,4 +701,58 @@ test('buildArray with repeated counters performs correct assignment', () => {
   ]
   buildArray(res, ctr, end, initials, steps, idx, ext, arr)
   expect(arr).toEqual(exp)
+})
+
+test('checkValidLoops accepts standard loops', () => {
+  // let i = 0; i < 10; i = i + 1
+  const end = [10]
+  const initials = [0]
+  const steps = [1]
+  const res = checkValidLoops(end, initials, steps)
+  expect(res).toEqual(true)
+})
+
+test('checkValidLoops accepts loops with non-standard initial/step size', () => {
+  // let i = 2; i < 10; i = i + 2
+  const end = [10]
+  const initials = [2]
+  const steps = [2]
+  const res = checkValidLoops(end, initials, steps)
+  expect(res).toEqual(true)
+})
+
+test('checkValidLoops rejects loops with non-integer initial', () => {
+  // let i = 0.5; i < 10; i = i + 2
+  const end = [10]
+  const initials = [0.5]
+  const steps = [2]
+  const res = checkValidLoops(end, initials, steps)
+  expect(res).toEqual(false)
+})
+
+test('checkValidLoops rejects loops with non-integer step size', () => {
+  // let i = 2; i < 10; i = i + 0.5
+  const end = [10]
+  const initials = [2]
+  const steps = [0.5]
+  const res = checkValidLoops(end, initials, steps)
+  expect(res).toEqual(false)
+})
+
+test('checkValidLoops rejects loops with negative initial', () => {
+  // let i = -2; i < 10; i = i + 1
+  const end = [10]
+  const initials = [-2]
+  const steps = [1]
+  const res = checkValidLoops(end, initials, steps)
+  expect(res).toEqual(false)
+})
+
+test('checkValidLoops rejects loops which end up with negative array indiices', () => {
+  // let i = 0; i < 10; i = i + (-1)
+  const end = [10]
+  const initials = [0]
+  const steps = [-1]
+  const res = checkValidLoops(end, initials, steps)
+  expect(res).toEqual(false)
 })

--- a/src/gpu/__tests__/runtimeUtils.ts
+++ b/src/gpu/__tests__/runtimeUtils.ts
@@ -74,7 +74,7 @@ test('getGPUKernelDimensions with external variables returns correct dimensions'
   const end2 = [3, 5, 1, 2]
   const initials2 = [0, 0, 0, 0]
   const steps2 = [1, 1, 1, 1]
-  const operators2 = ['<', '<', '<']
+  const operators2 = ['<', '<', '<', '<']
   const idx2 = ['l', 'test', 'k']
   const kernelDim2 = getGPUKernelDimensions(ctr2, end2, initials2, steps2, operators2, idx2)
   expect(kernelDim2).toEqual([1, 2])
@@ -131,6 +131,17 @@ test('getGPUKernelDimensions with <= operator and non-standard initial/step retu
   const idx = ['i', 'j', 'k']
   const kernelDim = getGPUKernelDimensions(ctr, end, initials, steps, operators, idx)
   expect(kernelDim).toEqual([3, 4, 5])
+})
+
+test('getGPUKernelDimensions where the loop condition fails from the start returns 0 dimension', () => {
+  const ctr = ['i', 'j', 'k']
+  const end = [10, 11, 12]
+  const initials = [1, 2, 3]
+  const steps = [2, 3, 4]
+  const operators = ['<=', '>', '<=']
+  const idx = ['i', 'j', 'k']
+  const kernelDim = getGPUKernelDimensions(ctr, end, initials, steps, operators, idx)
+  expect(kernelDim).toEqual([3, 0, 5])
 })
 
 test('checkArray returns true when array is valid with counter prefix', () => {

--- a/src/gpu/__tests__/runtimeUtils.ts
+++ b/src/gpu/__tests__/runtimeUtils.ts
@@ -764,6 +764,15 @@ test('checkValidLoops accepts loops with non-standard initial/step size', () => 
   expect(res).toEqual(true)
 })
 
+test('checkValidLoops acceps loops that decrement the counter', () => {
+  // let i = 10; i > 0; i = i + (-1) or i = i - 1
+  const end = [0]
+  const initials = [10]
+  const steps = [-1]
+  const res = checkValidLoops(end, initials, steps)
+  expect(res).toEqual(true)
+})
+
 test('checkValidLoops rejects loops with non-integer initial', () => {
   // let i = 0.5; i < 10; i = i + 2
   const end = [10]
@@ -791,11 +800,25 @@ test('checkValidLoops rejects loops with negative initial', () => {
   expect(res).toEqual(false)
 })
 
-test('checkValidLoops rejects loops which end up with negative array indiices', () => {
-  // let i = 0; i < 10; i = i + (-1)
+test('checkValidLoops rejects loops which would not terminate', () => {
+  // let i = 0; i < 10; i = i + (-1) or i = i - 1
   const end = [10]
   const initials = [0]
   const steps = [-1]
   const res = checkValidLoops(end, initials, steps)
   expect(res).toEqual(false)
+
+  // let i = 10; i > 0; i = i + 1
+  const end2 = [0]
+  const initials2 = [10]
+  const steps2 = [1]
+  const res2 = checkValidLoops(end2, initials2, steps2)
+  expect(res2).toEqual(false)
+
+  // let i = 0; i < 10; i = i + 0
+  const end3 = [10]
+  const initials3 = [0]
+  const steps3 = [0]
+  const res3 = checkValidLoops(end3, initials3, steps3)
+  expect(res3).toEqual(false)
 })

--- a/src/gpu/__tests__/runtimeUtils.ts
+++ b/src/gpu/__tests__/runtimeUtils.ts
@@ -5,16 +5,18 @@ test('getGPUKernelDimensions with counter prefix returns correct dimensions', ()
   const end = [3, 5, 1]
   const initials = [0, 0, 0]
   const steps = [1, 1, 1]
+  const operators = ['<', '<', '<']
   const idx = ['i', 'j', 'k']
-  const kernelDim = getGPUKernelDimensions(ctr, end, initials, steps, idx)
+  const kernelDim = getGPUKernelDimensions(ctr, end, initials, steps, operators, idx)
   expect(kernelDim).toEqual([1, 5, 3])
 
   const ctr2 = ['i', 'j', 'k', 'l']
   const end2 = [3, 5, 1, 2]
   const initials2 = [0, 0, 0, 0]
   const steps2 = [1, 1, 1, 1]
+  const operators2 = ['<', '<', '<', '<']
   const idx2 = ['i', 'j']
-  const kernelDim2 = getGPUKernelDimensions(ctr2, end2, initials2, steps2, idx2)
+  const kernelDim2 = getGPUKernelDimensions(ctr2, end2, initials2, steps2, operators2, idx2)
   expect(kernelDim2).toEqual([5, 3])
 })
 
@@ -23,16 +25,18 @@ test('getGPUKernlDimensions with counter combination returns correct dimensions'
   const end = [3, 2, 5]
   const initials = [0, 0, 0]
   const steps = [1, 1, 1]
+  const operators = ['<', '<', '<']
   const idx = ['j', 'k', 'i']
-  const kernelDim = getGPUKernelDimensions(ctr, end, initials, steps, idx)
+  const kernelDim = getGPUKernelDimensions(ctr, end, initials, steps, operators, idx)
   expect(kernelDim).toEqual([3, 5, 2])
 
   const ctr2 = ['i', 'j', 'k', 'l']
   const end2 = [3, 5, 1, 2]
   const initials2 = [0, 0, 0, 0]
   const steps2 = [1, 1, 1, 1]
+  const operators2 = ['<', '<', '<', '<']
   const idx2 = ['k', 'i']
-  const kernelDim2 = getGPUKernelDimensions(ctr2, end2, initials2, steps2, idx2)
+  const kernelDim2 = getGPUKernelDimensions(ctr2, end2, initials2, steps2, operators2, idx2)
   expect(kernelDim2).toEqual([3, 1])
 })
 
@@ -41,16 +45,18 @@ test('getGPUKernlDimensions with numbers returns correct dimensions', () => {
   const end = [3, 2, 5]
   const initials = [0, 0, 0]
   const steps = [1, 1, 1]
+  const operators = ['<', '<', '<']
   const idx = ['j', '1', 'i']
-  const kernelDim = getGPUKernelDimensions(ctr, end, initials, steps, idx)
+  const kernelDim = getGPUKernelDimensions(ctr, end, initials, steps, operators, idx)
   expect(kernelDim).toEqual([3, 2])
 
   const ctr2 = ['i', 'j', 'k', 'l']
   const end2 = [3, 5, 1, 2]
   const initials2 = [0, 0, 0, 0]
   const steps2 = [1, 1, 1, 1]
+  const operators2 = ['<', '<', '<']
   const idx2 = [3, 'i']
-  const kernelDim2 = getGPUKernelDimensions(ctr2, end2, initials2, steps2, idx2)
+  const kernelDim2 = getGPUKernelDimensions(ctr2, end2, initials2, steps2, operators2, idx2)
   expect(kernelDim2).toEqual([3])
 })
 
@@ -59,16 +65,18 @@ test('getGPUKernelDimensions with external variables returns correct dimensions'
   const end = [3, 2, 5]
   const initials = [0, 0, 0]
   const steps = [1, 1, 1]
+  const operators = ['<', '<', '<']
   const idx = ['test', '1', 'i']
-  const kernelDim = getGPUKernelDimensions(ctr, end, initials, steps, idx)
+  const kernelDim = getGPUKernelDimensions(ctr, end, initials, steps, operators, idx)
   expect(kernelDim).toEqual([3])
 
   const ctr2 = ['i', 'j', 'k', 'l']
   const end2 = [3, 5, 1, 2]
   const initials2 = [0, 0, 0, 0]
   const steps2 = [1, 1, 1, 1]
+  const operators2 = ['<', '<', '<']
   const idx2 = ['l', 'test', 'k']
-  const kernelDim2 = getGPUKernelDimensions(ctr2, end2, initials2, steps2, idx2)
+  const kernelDim2 = getGPUKernelDimensions(ctr2, end2, initials2, steps2, operators2, idx2)
   expect(kernelDim2).toEqual([1, 2])
 })
 
@@ -77,17 +85,52 @@ test('getGPUKernelDimensions with repeated counters returns correct dimensions',
   const end = [3, 2, 5]
   const initials = [0, 0, 0]
   const steps = [1, 1, 1]
+  const operators = ['<', '<', '<']
   const idx = ['i', 'i', 'k']
-  const kernelDim = getGPUKernelDimensions(ctr, end, initials, steps, idx)
+  const kernelDim = getGPUKernelDimensions(ctr, end, initials, steps, operators, idx)
   expect(kernelDim).toEqual([5, 3])
 
   const ctr2 = ['i', 'j', 'k', 'l']
   const end2 = [3, 5, 1, 2]
   const initials2 = [0, 0, 0, 0]
   const steps2 = [1, 1, 1, 1]
+  const operators2 = ['<', '<', '<', '<']
   const idx2 = ['l', 'k', 'l']
-  const kernelDim2 = getGPUKernelDimensions(ctr2, end2, initials2, steps2, idx2)
+  const kernelDim2 = getGPUKernelDimensions(ctr2, end2, initials2, steps2, operators2, idx2)
   expect(kernelDim2).toEqual([1, 2])
+})
+
+test('getGPUKernelDimensions with non-standard initial/step returns correct dimensions', () => {
+  const ctr = ['i', 'j', 'k']
+  const end = [10, 11, 12]
+  const initials = [1, 2, 3]
+  const steps = [2, 3, 4]
+  const operators = ['<', '<', '<']
+  const idx = ['i', 'j', 'k']
+  const kernelDim = getGPUKernelDimensions(ctr, end, initials, steps, operators, idx)
+  expect(kernelDim).toEqual([3, 3, 5])
+})
+
+test('getGPUKernelDimensions with <= operator returns correct dimensions', () => {
+  const ctr = ['i', 'j', 'k']
+  const end = [3, 5, 1]
+  const initials = [0, 0, 0]
+  const steps = [1, 1, 1]
+  const operators = ['<=', '<=', '<=']
+  const idx = ['i', 'j', 'k']
+  const kernelDim = getGPUKernelDimensions(ctr, end, initials, steps, operators, idx)
+  expect(kernelDim).toEqual([2, 6, 4])
+})
+
+test('getGPUKernelDimensions with <= operator and non-standard initial/step returns correct dimensions', () => {
+  const ctr = ['i', 'j', 'k']
+  const end = [10, 11, 12]
+  const initials = [1, 2, 3]
+  const steps = [2, 3, 4]
+  const operators = ['<=', '<=', '<=']
+  const idx = ['i', 'j', 'k']
+  const kernelDim = getGPUKernelDimensions(ctr, end, initials, steps, operators, idx)
+  expect(kernelDim).toEqual([3, 4, 5])
 })
 
 test('checkArray returns true when array is valid with counter prefix', () => {

--- a/src/gpu/__tests__/transpile.ts
+++ b/src/gpu/__tests__/transpile.ts
@@ -341,3 +341,35 @@ test('resolve naming conflicts by disabling automatic optimizations', () => {
   )?.length
   expect(cntWarnings).toEqual(1)
 })
+
+test('simple for loop with different update gets transpiled', () => {
+  const code = stripIndent`
+    let res = [];
+    for (let i = 0; i < 5; i = i + 2) {
+        res[i] = i;
+    }
+    `
+  const context = mockContext(4, 'gpu')
+  const program = parse(code, context)!
+  transpileToGPU(program)
+  const transpiled = generate(program)
+
+  const cnt = transpiled.match(/__createKernelSource/g)?.length
+  expect(cnt).toEqual(1)
+})
+
+test('simple for loop with non-zero initialization gets transpiled', () => {
+  const code = stripIndent`
+    let res = [];
+    for (let i = 1; i < 5; i = i + 1) {
+        res[i] = i;
+    }
+    `
+  const context = mockContext(4, 'gpu')
+  const program = parse(code, context)!
+  transpileToGPU(program)
+  const transpiled = generate(program)
+
+  const cnt = transpiled.match(/__createKernelSource/g)?.length
+  expect(cnt).toEqual(1)
+})

--- a/src/gpu/lib.ts
+++ b/src/gpu/lib.ts
@@ -184,6 +184,29 @@ function buildArrayHelper(
 }
 
 /*
+ * This helper function checks that the loops are valid
+ * 1. All initial values and step sizes are integers (then array indices will always be integers)
+ * 2. The array index is always non-negative from initial to end
+ */
+export function checkValidLoops(end: any, initials: any, steps: any): boolean {
+  for (let i = 0; i < end.length; i++) {
+    const e = end[i]
+    const initial = initials[i]
+    const step = steps[i]
+
+    // 1. All initial values and step sizes are integers
+    if (!Number.isInteger(initial) || !Number.isInteger(step)) {
+      return false
+    }
+
+    // 2. The array index is always non-negative from initial to end
+    if (initial < 0 || step <= 0 || (e - initial) / step < 0) {
+      return false
+    }
+  }
+  return true
+}
+/*
  * we only use the gpu if:
  * 1. we are working with numbers
  * 2. we have a large array (> 100 elements)
@@ -339,6 +362,10 @@ export function __createKernelSource(
   kernelId: number,
   functionEntries: [string, any][]
 ) {
+  if (!checkValidLoops(end, initials, steps)) {
+    throw 'Loop is invalid'
+  }
+
   const extern = entriesToObject(externSource)
   // Create a set of function names (used in transpilation methods)
   const customFunctionNames = new Set<string>()

--- a/src/gpu/lib.ts
+++ b/src/gpu/lib.ts
@@ -21,13 +21,24 @@ export function getGPUKernelDimensions(
 ) {
   const dimMap = {}
   for (let i = 0; i < ctr.length; i++) {
-    let dimension = Math.ceil((end[i] - initials[i]) / steps[i])
-    // handle the operators <= and >=, where the equality condition might cause dimension to be larger by 1
-    const finalVal = initials[i] + steps[i] * dimension
-    if (evaluateBinaryExpression(operators[i] as es.BinaryOperator, finalVal, end[i])) {
-      dimension += 1
+    const op = operators[i] as es.BinaryOperator
+    const e = end[i]
+    const initial = initials[i]
+    const step = steps[i]
+    // handle the case where the condition already fails at the start of the loop (initial op end === false)
+    if (!evaluateBinaryExpression(op, initial, e)) {
+      // then the dimension will be 0
+      dimMap[ctr[i]] = 0
+    } else {
+      // calculate dimension based on step size
+      let dimension = Math.ceil((e - initial) / step)
+      // handle the operators <= and >=, where the equality condition might cause dimension to be larger by 1
+      const finalVal = initial + step * dimension
+      if (evaluateBinaryExpression(op, finalVal, e)) {
+        dimension += 1
+      }
+      dimMap[ctr[i]] = dimension
     }
-    dimMap[ctr[i]] = dimension
   }
   const used: string[] = []
   const dim: number[] = []

--- a/src/gpu/transfomer.ts
+++ b/src/gpu/transfomer.ts
@@ -32,6 +32,7 @@ class GPUTransformer {
   end: es.Expression[]
   steps: es.Expression[]
   initials: es.Expression[]
+  operators: es.BinaryOperator[]
 
   state: number
   indices: (string | number)[]
@@ -88,6 +89,7 @@ class GPUTransformer {
     this.end = []
     this.initials = []
     this.steps = []
+    this.operators = []
 
     // 1. verification of outer loops + body
     this.checkOuterLoops(node)
@@ -211,12 +213,14 @@ class GPUTransformer {
       const endToTranspile = []
       const initialToTranspile = []
       const stepToTranspile = []
+      const operatorToTranspile = []
       for (let i = 0; i < this.counters.length; i++) {
         if (!untranspiledCounters.includes(this.counters[i])) {
           ctrToTranspile.push(this.counters[i])
           endToTranspile.push(this.end[i])
           initialToTranspile.push(this.initials[i])
           stepToTranspile.push(this.steps[i])
+          operatorToTranspile.push(this.operators[i])
         }
       }
 
@@ -247,6 +251,7 @@ class GPUTransformer {
           create.arrayExpression(endToTranspile),
           create.arrayExpression(initialToTranspile),
           create.arrayExpression(stepToTranspile),
+          create.arrayExpression(operatorToTranspile.map(x => create.literal(x))),
           create.arrayExpression(toParallelize.map(x => create.literal(x))),
           create.arrayExpression(externEntries.map(create.arrayExpression)),
           create.arrayExpression(Array.from(locals.values()).map(v => create.literal(v))),
@@ -302,6 +307,7 @@ class GPUTransformer {
       this.end.push(detector.end)
       this.initials.push(detector.initial)
       this.steps.push(detector.step)
+      this.operators.push(detector.operator)
 
       if (this.innerBody.type !== 'BlockStatement') {
         break

--- a/src/gpu/transfomer.ts
+++ b/src/gpu/transfomer.ts
@@ -33,6 +33,7 @@ class GPUTransformer {
   steps: es.Expression[]
   initials: es.Expression[]
   operators: es.BinaryOperator[]
+  isIncrements: boolean[]
 
   state: number
   indices: (string | number)[]
@@ -90,6 +91,7 @@ class GPUTransformer {
     this.initials = []
     this.steps = []
     this.operators = []
+    this.isIncrements = []
 
     // 1. verification of outer loops + body
     this.checkOuterLoops(node)
@@ -214,6 +216,7 @@ class GPUTransformer {
       const initialToTranspile = []
       const stepToTranspile = []
       const operatorToTranspile = []
+      const isIncrementsToTranspile = []
       for (let i = 0; i < this.counters.length; i++) {
         if (!untranspiledCounters.includes(this.counters[i])) {
           ctrToTranspile.push(this.counters[i])
@@ -221,6 +224,7 @@ class GPUTransformer {
           initialToTranspile.push(this.initials[i])
           stepToTranspile.push(this.steps[i])
           operatorToTranspile.push(this.operators[i])
+          isIncrementsToTranspile.push(this.isIncrements[i])
         }
       }
 
@@ -252,6 +256,7 @@ class GPUTransformer {
           create.arrayExpression(initialToTranspile),
           create.arrayExpression(stepToTranspile),
           create.arrayExpression(operatorToTranspile.map(x => create.literal(x))),
+          create.arrayExpression(isIncrementsToTranspile.map(x => create.literal(x))),
           create.arrayExpression(toParallelize.map(x => create.literal(x))),
           create.arrayExpression(externEntries.map(create.arrayExpression)),
           create.arrayExpression(Array.from(locals.values()).map(v => create.literal(v))),
@@ -308,6 +313,7 @@ class GPUTransformer {
       this.initials.push(detector.initial)
       this.steps.push(detector.step)
       this.operators.push(detector.operator)
+      this.isIncrements.push(detector.isIncrement)
 
       if (this.innerBody.type !== 'BlockStatement') {
         break

--- a/src/gpu/transfomer.ts
+++ b/src/gpu/transfomer.ts
@@ -26,8 +26,13 @@ class GPUTransformer {
 
   outputArray: es.Identifier
   innerBody: any
+
+  // info about the for loops
   counters: string[]
   end: es.Expression[]
+  steps: es.Expression[]
+  initials: es.Expression[]
+
   state: number
   indices: (string | number)[]
   localVar: Set<string>
@@ -81,6 +86,8 @@ class GPUTransformer {
     this.state = 0
     this.counters = []
     this.end = []
+    this.initials = []
+    this.steps = []
 
     // 1. verification of outer loops + body
     this.checkOuterLoops(node)
@@ -202,10 +209,14 @@ class GPUTransformer {
     const makeCreateKernelSourceCall = (arr: es.Identifier): es.CallExpression => {
       const ctrToTranspile = []
       const endToTranspile = []
+      const initialToTranspile = []
+      const stepToTranspile = []
       for (let i = 0; i < this.counters.length; i++) {
         if (!untranspiledCounters.includes(this.counters[i])) {
           ctrToTranspile.push(this.counters[i])
           endToTranspile.push(this.end[i])
+          initialToTranspile.push(this.initials[i])
+          stepToTranspile.push(this.steps[i])
         }
       }
 
@@ -234,6 +245,8 @@ class GPUTransformer {
         [
           create.arrayExpression(ctrToTranspile.map(x => create.literal(x))),
           create.arrayExpression(endToTranspile),
+          create.arrayExpression(initialToTranspile),
+          create.arrayExpression(stepToTranspile),
           create.arrayExpression(toParallelize.map(x => create.literal(x))),
           create.arrayExpression(externEntries.map(create.arrayExpression)),
           create.arrayExpression(Array.from(locals.values()).map(v => create.literal(v))),
@@ -287,6 +300,8 @@ class GPUTransformer {
       this.innerBody = currForLoop.body
       this.counters.push(detector.counter)
       this.end.push(detector.end)
+      this.initials.push(detector.initial)
+      this.steps.push(detector.step)
 
       if (this.innerBody.type !== 'BlockStatement') {
         break
@@ -379,6 +394,8 @@ export function gpuRuntimeTranspile(
   node: es.ArrowFunctionExpression,
   localNames: Set<string>,
   end: number[],
+  initials: number[],
+  steps: number[],
   idx: (string | number)[],
   functionNames: Set<string>
 ): es.BlockStatement {
@@ -441,19 +458,40 @@ export function gpuRuntimeTranspile(
 
   const threads = ['x', 'y', 'z']
   const counterMap = {}
+  const initialMap = {}
+  const stepMap = {}
   for (let i = 0; i < counterIdx.length; i++) {
     counterMap[counterIdx[i]] = threads[i]
+    // initial and step are obtained in the reverse order
+    initialMap[counterIdx[i]] = initials[counterIdx.length - i - 1]
+    stepMap[counterIdx[i]] = steps[counterIdx.length - i - 1]
   }
 
   simple(body, {
     Identifier(nx: es.Identifier) {
       if (nx.name in counterMap) {
         const id = counterMap[nx.name]
-        create.mutateToMemberExpression(
-          nx,
+        const initial = initialMap[nx.name]
+        const step = stepMap[nx.name]
+
+        if (initial === 0 && step === 1) {
+          // if initial and step are standard, no need to mutate with arithmetic
+          create.mutateToMemberExpression(
+            nx,
+            create.memberExpression(create.identifier('this'), 'thread'),
+            create.identifier(id)
+          )
+          return
+        }
+        // map this.thread.x/y/z to the 'correct' value by accounting for initial and step
+        // initial + this.thread.x/y/z * step
+        const thisThreadExpr = create.memberExpression(
           create.memberExpression(create.identifier('this'), 'thread'),
-          create.identifier(id)
+          id
         )
+        const multiplyExpr = create.binaryExpression('*', thisThreadExpr, create.literal(step))
+
+        create.mutateToBinaryExpression(nx, '+', create.literal(initial), multiplyExpr)
       }
     }
   })

--- a/src/gpu/verification/loopVerifier.ts
+++ b/src/gpu/verification/loopVerifier.ts
@@ -13,11 +13,12 @@ class GPULoopVerifier {
   ok: boolean
 
   // info about the structure of the for loop
-  // for (let |counter| = |initial|; |counter| < |end|; |counter| = |counter| + |step|)
+  // for (let |counter| = |initial|; |counter| |operator| |end|; |counter| = |counter| + |step|)
   counter: string
   initial: es.Expression
   step: es.Expression
   end: es.Expression
+  operator: es.BinaryOperator
 
   constructor(node: es.ForStatement) {
     this.node = node
@@ -80,6 +81,7 @@ class GPULoopVerifier {
     if (!(node.operator === '<' || node.operator === '<=')) {
       return false
     }
+    this.operator = node.operator
 
     const lv: es.Expression = node.left
     if (!this.isCounter(lv)) {

--- a/src/gpu/verification/loopVerifier.ts
+++ b/src/gpu/verification/loopVerifier.ts
@@ -14,11 +14,13 @@ class GPULoopVerifier {
 
   // info about the structure of the for loop
   // for (let |counter| = |initial|; |counter| |operator| |end|; |counter| = |counter| + |step|)
+  // isIncrement is true if the operator in gpu_for_assignment is +, and false if the operator is -
   counter: string
   initial: es.Expression
   step: es.Expression
   end: es.Expression
   operator: es.BinaryOperator
+  isIncrement: boolean
 
   constructor(node: es.ForStatement) {
     this.node = node
@@ -78,7 +80,14 @@ class GPULoopVerifier {
       return false
     }
 
-    if (!(node.operator === '<' || node.operator === '<=')) {
+    if (
+      !(
+        node.operator === '<' ||
+        node.operator === '<=' ||
+        node.operator === '>' ||
+        node.operator === '>='
+      )
+    ) {
       return false
     }
     this.operator = node.operator
@@ -120,7 +129,11 @@ class GPULoopVerifier {
     }
 
     const rv = node.right
-    if (rv.operator !== '+') {
+    if (rv.operator === '+') {
+      this.isIncrement = true
+    } else if (rv.operator === '-') {
+      this.isIncrement = false
+    } else {
       return false
     }
 

--- a/src/utils/astCreator.ts
+++ b/src/utils/astCreator.ts
@@ -201,6 +201,19 @@ export const mutateToAssignmentExpression = (
   node.right = right
 }
 
+export const mutateToBinaryExpression = (
+  node: es.Node,
+  operator: es.BinaryOperator,
+  left: es.Expression,
+  right: es.Expression
+) => {
+  node.type = 'BinaryExpression'
+  node = node as es.BinaryExpression
+  node.operator = operator
+  node.left = left
+  node.right = right
+}
+
 export const mutateToExpressionStatement = (node: es.Node, expr: es.Expression) => {
   node.type = 'ExpressionStatement'
   node = node as es.ExpressionStatement


### PR DESCRIPTION
This PR will add support for non-standard for loops.

Currently, for loops are restricted to be
`for (let counter = 0; counter (< or <=) number; counter = counter + 1)`

This extension will expand the scope of parallelisable for loops to be
`for (let counter = integer; counter (< or <= or > or >=) number; counter = counter (+ or -) integer)`

Essentially, we can have a varying initial value and step size for the counter.